### PR TITLE
feat: Switch from SNS Topic Publishing to E-Mail recipients

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ to effectively manage their AWS costs.
 | <a name="input_budgets"></a> [budgets](#input\_budgets) | The list of budget. | <pre>list(object({<br>    name              = string<br>    budget_type       = string<br>    limit_amount      = string<br>    limit_unit        = string<br>    time_period_start = string<br>    time_period_end   = string<br>    time_unit         = string<br><br>    cost_filter = optional(map(list(string)))<br><br>    notification = object({<br>      comparison_operator = string<br>      threshold           = string<br>      threshold_type      = string<br>      notification_type   = string<br>    })<br>  }))</pre> | <pre>[<br>  {<br>    "budget_type": "COST",<br>    "limit_amount": "200",<br>    "limit_unit": "USD",<br>    "name": "budget-account-monthly",<br>    "notification": {<br>      "comparison_operator": "GREATER_THAN",<br>      "notification_type": "FORECASTED",<br>      "threshold": "100",<br>      "threshold_type": "PERCENTAGE"<br>    },<br>    "time_period_end": "2087-06-15_00:00",<br>    "time_period_start": "2023-01-01_00:00",<br>    "time_unit": "MONTHLY"<br>  }<br>]</pre> | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the budget. | `string` | n/a | yes |
 | <a name="input_recipients"></a> [recipients](#input\_recipients) | The email addresses to send notifications to. | `list(string)` | n/a | yes |
-| <a name="input_tags"></a> [tags](#input\_tags) | Tags to add to the AWS Backup. | `map(any)` | `{}` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -46,5 +46,3 @@ resource "aws_budgets_budget" "main" {
     threshold_type             = each.value.notification.threshold_type
   }
 }
-
-

--- a/main.tf
+++ b/main.tf
@@ -39,19 +39,12 @@ resource "aws_budgets_budget" "main" {
   }
 
   notification {
-    comparison_operator       = each.value.notification.comparison_operator
-    notification_type         = each.value.notification.notification_type
-    subscriber_sns_topic_arns = [module.notification.arn]
-    threshold                 = each.value.notification.threshold
-    threshold_type            = each.value.notification.threshold_type
+    comparison_operator        = each.value.notification.comparison_operator
+    notification_type          = each.value.notification.notification_type
+    subscriber_email_addresses = var.recipients
+    threshold                  = each.value.notification.threshold
+    threshold_type             = each.value.notification.threshold_type
   }
 }
 
-module "notification" {
-  source = "github.com/geekcell/terraform-aws-sns-email-notification?ref=v1.1"
 
-  name            = "${var.name}-budgets"
-  email_addresses = var.recipients
-
-  tags = var.tags
-}

--- a/variables.tf
+++ b/variables.tf
@@ -1,10 +1,3 @@
-# Context
-variable "tags" {
-  description = "Tags to add to the AWS Backup."
-  default     = {}
-  type        = map(any)
-}
-
 # AWS Budgets
 variable "budgets" {
   default = [


### PR DESCRIPTION
<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->

## What it solves

AWS Budgets was unable to SNS:Publish an SNS Topic

## How this PR fixes it

Use E-Mail recipients and not an SNS Topic

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request
- [ ] Pull request title is brief and descriptive (for a changelog entry)

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, or `enhancement`
- [ ] Label as `bump:patch`, `bump:minor`, or `bump:major` if this PR should create a new release
